### PR TITLE
Add view project link and download link

### DIFF
--- a/app/routes/preprints.js
+++ b/app/routes/preprints.js
@@ -3,13 +3,14 @@ import config from 'ember-get-config';
 
 export default Ember.Route.extend({
     model(params) {
-    console.log(config);
             return Ember.RSVP.hash({
             id: params.file_id,
             baseUrl: config.OSF.url,
             renderUrl: config.OSF.renderUrl,
             // JamDB
             preprint: this.store.findRecord('preprint', params.file_id),
+            project: this.store.findRecord('file', '57755becda3e2401f3efd988').then(file => file.get('links').download.split('/')[5]),
+            downloadLink: this.store.findRecord('file', '57755becda3e2401f3efd988').then(file => file.get('links').download)
         });
     },
 });

--- a/app/templates/preprints.hbs
+++ b/app/templates/preprints.hbs
@@ -56,9 +56,12 @@ hr {
                             <p>The project for this paper is available on the Open Science Framework</p>
                         </div>
                         <div class="col-md-4">
-                            <a type="button" class="btn btn-primary" href={{concat model.baseUrl model.id}}>View project</a>
+                            <a type="button" class="btn btn-primary" href={{concat model.baseUrl model.project}}>View project</a>
                         </div>
                     </div>
+                    <a href={{model.downloadLink}}>
+                        Download preprint
+                    </a>
                     <br>
                     <br>
                     <div class="row" id="right_panel">


### PR DESCRIPTION
Thanks to Ellis, now the View Project button actually takes you to the project that the preprint is saved under.

Note: Currently it is hard coded with a file ID because we are waiting on the Jam data to be updated with a path field.
